### PR TITLE
fix(esp32h2): prevent sleep divide-by-zero on rev0.2

### DIFF
--- a/esp-hal/src/clock/mod.rs
+++ b/esp-hal/src/clock/mod.rs
@@ -320,18 +320,22 @@ impl Clocks {
         use esp_rom_sys::rom::ets_delay_us;
 
         #[cfg(timergroup_rc_fast_calibration_divider)]
-        let use_rc_fast_calibration_divider = rtc_clock == TimgCalibrationClockConfig::RcFastDivClk
+        let calibration_divider = if rtc_clock == TimgCalibrationClockConfig::RcFastDivClk
             && crate::soc::chip_revision_above(ChipRevision::from_combined(property!(
                 "timergroup.rc_fast_calibration_divider_min_rev"
-            )));
-        #[cfg(timergroup_rc_fast_calibration_divider)]
-        let calibration_divider = if use_rc_fast_calibration_divider {
+            ))) {
             property!("timergroup.rc_fast_calibration_divider")
         } else {
             1
         };
         #[cfg(not(timergroup_rc_fast_calibration_divider))]
         let calibration_divider = 1;
+
+        #[cfg(all(timergroup_rc_fast_calibration_divider, esp32h2))]
+        let use_rc_fast_calibration_divider = rtc_clock == TimgCalibrationClockConfig::RcFastDivClk
+            && crate::soc::chip_revision_above(ChipRevision::from_combined(property!(
+                "timergroup.rc_fast_calibration_divider_min_rev"
+            )));
 
         // On some revisions calibration uses a divided RC_FAST tick.
         let calibration_cycles = (slow_cycles / calibration_divider).max(1);

--- a/esp-hal/src/clock/mod.rs
+++ b/esp-hal/src/clock/mod.rs
@@ -70,7 +70,7 @@ use crate::efuse::ChipRevision;
 #[cfg(all(
     soc_has_clock_node_timg_calibration_clock,
     timergroup_rc_fast_calibration_divider,
-    any(esp32c6, esp32h2)
+    esp32h2
 ))]
 use crate::peripherals::PCR;
 #[instability::unstable]
@@ -361,7 +361,7 @@ impl Clocks {
         clocks::request_timg_calibration_clock(clocks);
 
         // Align with IDF ECO-specific RC_FAST calibration flow.
-        #[cfg(all(timergroup_rc_fast_calibration_divider, any(esp32c6, esp32h2)))]
+        #[cfg(all(timergroup_rc_fast_calibration_divider, esp32h2))]
         if use_rc_fast_calibration_divider {
             PCR::regs()
                 .ctrl_tick_conf()
@@ -441,7 +441,7 @@ impl Clocks {
             .rtccalicfg()
             .modify(|_, w| w.rtc_cali_start().clear_bit());
 
-        #[cfg(all(timergroup_rc_fast_calibration_divider, any(esp32c6, esp32h2)))]
+        #[cfg(all(timergroup_rc_fast_calibration_divider, esp32h2))]
         if use_rc_fast_calibration_divider {
             PCR::regs()
                 .ctrl_tick_conf()

--- a/esp-hal/src/clock/mod.rs
+++ b/esp-hal/src/clock/mod.rs
@@ -67,6 +67,12 @@ pub mod ll {
 
 #[cfg(timergroup_rc_fast_calibration_divider)]
 use crate::efuse::ChipRevision;
+#[cfg(all(
+    soc_has_clock_node_timg_calibration_clock,
+    timergroup_rc_fast_calibration_divider,
+    any(esp32c6, esp32h2)
+))]
+use crate::peripherals::PCR;
 #[instability::unstable]
 pub use crate::soc::clocks::ClockConfig;
 pub use crate::soc::clocks::CpuClock;
@@ -314,10 +320,12 @@ impl Clocks {
         use esp_rom_sys::rom::ets_delay_us;
 
         #[cfg(timergroup_rc_fast_calibration_divider)]
-        let calibration_divider = if rtc_clock == TimgCalibrationClockConfig::RcFastDivClk
+        let use_rc_fast_calibration_divider = rtc_clock == TimgCalibrationClockConfig::RcFastDivClk
             && crate::soc::chip_revision_above(ChipRevision::from_combined(property!(
                 "timergroup.rc_fast_calibration_divider_min_rev"
-            ))) {
+            )));
+        #[cfg(timergroup_rc_fast_calibration_divider)]
+        let calibration_divider = if use_rc_fast_calibration_divider {
             property!("timergroup.rc_fast_calibration_divider")
         } else {
             1
@@ -351,6 +359,14 @@ impl Clocks {
         let current_calib_clock = clocks::timg_calibration_clock_config(clocks);
         clocks::configure_timg_calibration_clock(clocks, rtc_clock);
         clocks::request_timg_calibration_clock(clocks);
+
+        // Align with IDF ECO-specific RC_FAST calibration flow.
+        #[cfg(all(timergroup_rc_fast_calibration_divider, any(esp32c6, esp32h2)))]
+        if use_rc_fast_calibration_divider {
+            PCR::regs()
+                .ctrl_tick_conf()
+                .modify(|_, w| w.tick_enable().set_bit());
+        }
 
         let calibration_clock_frequency = clocks::timg_calibration_clock_frequency(clocks);
 
@@ -424,6 +440,13 @@ impl Clocks {
         TIMG0::regs()
             .rtccalicfg()
             .modify(|_, w| w.rtc_cali_start().clear_bit());
+
+        #[cfg(all(timergroup_rc_fast_calibration_divider, any(esp32c6, esp32h2)))]
+        if use_rc_fast_calibration_divider {
+            PCR::regs()
+                .ctrl_tick_conf()
+                .modify(|_, w| w.tick_enable().clear_bit());
+        }
 
         if let Some(calib_clock) = current_calib_clock
             && calib_clock != rtc_clock

--- a/esp-hal/src/rtc_cntl/rtc/esp32h2.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32h2.rs
@@ -74,6 +74,8 @@ pub(crate) fn init() {
     }
 
     // Keep RC_FAST calibration timing aligned with ESP-IDF for H2.
+    // IDF applies `fosc_tick_num = 255` for RC_FAST calibration setup without
+    // revision gating; only `tick_enable` is ECO2+-specific.
     PCR::regs()
         .ctrl_tick_conf()
         .modify(|_, w| unsafe { w.fosc_tick_num().bits(255) });

--- a/esp-hal/src/rtc_cntl/rtc/esp32h2.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32h2.rs
@@ -73,11 +73,10 @@ pub(crate) fn init() {
             .modify(|_, w| w.ana_wait_target().bits(1700));
     }
 
-    // Keep RC_FAST calibration timing aligned with ESP-IDF for H2 ECO2+.
-    PCR::regs().ctrl_tick_conf().modify(|_, w| unsafe {
-        w.fosc_tick_num().bits(255);
-        w.tick_enable().set_bit()
-    });
+    // Keep RC_FAST calibration timing aligned with ESP-IDF for H2.
+    PCR::regs()
+        .ctrl_tick_conf()
+        .modify(|_, w| unsafe { w.fosc_tick_num().bits(255) });
 }
 
 // Terminology:

--- a/esp-hal/src/rtc_cntl/rtc/esp32h2.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32h2.rs
@@ -1,6 +1,9 @@
 use strum::FromRepr;
 
-use crate::{peripherals::PMU, soc::regi2c};
+use crate::{
+    peripherals::{PCR, PMU},
+    soc::regi2c,
+};
 
 pub(crate) fn init() {
     // * No peripheral reg i2c power up required on the target */
@@ -69,6 +72,11 @@ pub(crate) fn init() {
         pmu.slp_wakeup_cntl7()
             .modify(|_, w| w.ana_wait_target().bits(1700));
     }
+
+    // Keep RC_FAST calibration timing aligned with ESP-IDF for H2 ECO2+.
+    PCR::regs()
+        .ctrl_tick_conf()
+        .modify(|r, w| unsafe { w.bits((r.bits() & !(0xff << 8)) | (0xff << 8) | (1 << 16)) });
 }
 
 // Terminology:

--- a/esp-hal/src/rtc_cntl/rtc/esp32h2.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32h2.rs
@@ -74,9 +74,10 @@ pub(crate) fn init() {
     }
 
     // Keep RC_FAST calibration timing aligned with ESP-IDF for H2 ECO2+.
-    PCR::regs()
-        .ctrl_tick_conf()
-        .modify(|r, w| unsafe { w.bits((r.bits() & !(0xff << 8)) | (0xff << 8) | (1 << 16)) });
+    PCR::regs().ctrl_tick_conf().modify(|_, w| unsafe {
+        w.fosc_tick_num().bits(255);
+        w.tick_enable().set_bit()
+    });
 }
 
 // Terminology:

--- a/esp-hal/src/rtc_cntl/sleep/esp32h2.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32h2.rs
@@ -503,14 +503,7 @@ impl SleepTimeConfig {
 
         // Calibrate rtc fast clock, only PMU supported chips sleep process is needed.
         const FAST_CLK_SRC_CAL_CYCLES: u32 = 2048;
-        let fastclk_period = match Self::rtc_clk_cal_fast(FAST_CLK_SRC_CAL_CYCLES) {
-            0 => {
-                // Fall back to the nominal RC_FAST frequency to avoid panicking when sleep
-                // timing conversion runs before a successful calibration.
-                ((1_000_000u64 << Self::RTC_CLK_CAL_FRACT) / 8_000_000u64) as u32
-            }
-            period => period,
-        };
+        let fastclk_period = Self::rtc_clk_cal_fast(FAST_CLK_SRC_CAL_CYCLES);
 
         Self {
             sleep_time_adjustment: 0,

--- a/esp-hal/src/rtc_cntl/sleep/esp32h2.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32h2.rs
@@ -503,7 +503,14 @@ impl SleepTimeConfig {
 
         // Calibrate rtc fast clock, only PMU supported chips sleep process is needed.
         const FAST_CLK_SRC_CAL_CYCLES: u32 = 2048;
-        let fastclk_period = Self::rtc_clk_cal_fast(FAST_CLK_SRC_CAL_CYCLES);
+        let fastclk_period = match Self::rtc_clk_cal_fast(FAST_CLK_SRC_CAL_CYCLES) {
+            0 => {
+                // Fall back to the nominal RC_FAST frequency to avoid panicking when sleep
+                // timing conversion runs before a successful calibration.
+                ((1_000_000u64 << Self::RTC_CLK_CAL_FRACT) / 8_000_000u64) as u32
+            }
+            period => period,
+        };
 
         Self {
             sleep_time_adjustment: 0,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the latest [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
This change aligns ESP32-H2 RC_FAST calibration/sleep behavior with ESP-IDF for ECO2+, scoped to H2 only.

What changed:
- In `esp-hal/src/rtc_cntl/rtc/esp32h2.rs`, configure `PCR::ctrl_tick_conf.fosc_tick_num = 255` during RTC init (IDF `clk_ll_rc_fast_tick_conf` behavior). This setting is applied on all H2 revisions (matching IDF), while ECO2+ specific behavior is controlled by calibration-time `tick_enable` handling.
- In `esp-hal/src/clock/mod.rs`, add H2-only (`cfg(esp32h2)`) `tick_enable` toggling around ECO-specific RC_FAST calibration and clear it after calibration, matching IDF’s H2 calibration flow.
- Shared calibration divider logic in `clock/mod.rs` remains unchanged from `main`; only H2-specific blocks were added.
- In `esp-hal/src/rtc_cntl/sleep/esp32h2.rs`, remove the Rust-specific nominal 8 MHz fallback to keep behavior consistent with IDF semantics.
- Use typed esp-pacs field access (`fosc_tick_num`, `tick_enable`) instead of raw bit manipulation.

Motivation:
- Ensure H2 rev0.2 calibration path follows the same clock/tick control sequence as IDF without changing other chips.

#### Testing
- Runtime reproduction target: `qa-test/src/bin/sleep_timer.rs` on ESP32-H2 rev0.2 (issue context).
- Local compile/test automation in this cloud environment is blocked because the available Cargo version is too old for this repository's `edition = "2024"` manifests (`Cargo 1.83.0`), so I could not run `cargo check` or formatting tasks here.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55813b36-657b-47ff-bcf0-678d1ffc6604"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55813b36-657b-47ff-bcf0-678d1ffc6604"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

