### PR TITLE
xtask: avoid self-copy of LP example artifacts

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -631,10 +631,17 @@ fn run_ci_checks(workspace: &Path, args: CiArgs) -> Result<()> {
                     && example_path.extension().is_none()
                 {
                     let example_name = example.file_name().to_string_lossy().to_string();
-                    let without_fingerprint = example_name
-                        .rsplit_once('-')
-                        .map(|(a, _)| a)
-                        .unwrap_or(&example_name);
+                    let Some((without_fingerprint, fingerprint)) = example_name.rsplit_once('-')
+                    else {
+                        // Skip non-fingerprinted files to avoid self-copying
+                        // artifacts (for example "blinky" -> "blinky").
+                        continue;
+                    };
+                    // Cargo fingerprints are hexadecimal, so only rewrite files
+                    // that actually look like fingerprinted artifacts.
+                    if !fingerprint.chars().all(|c| c.is_ascii_hexdigit()) {
+                        continue;
+                    }
 
                     let dst = dir.join(without_fingerprint);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the latest [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Fixes a nondeterministic CI failure in the LP example staging step used by `cargo xcheck ci` for LP-core chips.

`xtask` iterated over all files in `esp-lp-hal/target/*/release/examples` and copied each one to a de-fingerprinted destination. On some runners the directory contains both:
- a plain executable name (e.g. `blinky`)
- a fingerprinted artifact (e.g. `blinky-<hex>`)

When the plain name is processed, the old logic can copy `blinky` to `blinky` (same path). Depending on platform/filesystem behavior and iteration order, this can corrupt/truncate the binary and later cause:

`error: Error: Could not read file magic`

from `load_lp_code!` in `examples/peripheral/lp_core/lp_blinky`.

This patch only rewrites files that look fingerprinted (`<name>-<hex>`), skipping non-fingerprinted files entirely.

#### Testing
Attempted locally in this cloud environment:
- `cargo check -p xtask` ❌ fails before build due toolchain being too old for `edition2024` (`cargo 1.83.0`).
- `cargo +esp check -p xtask` ❌ `esp` toolchain not installed.

No additional code changes were required after these checks.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-84dc96f9-cb26-4a81-8c49-90429aded318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-84dc96f9-cb26-4a81-8c49-90429aded318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

