### PR TITLE
Fix esp32c2 debug overflow in embassy_coex example

### DIFF
--- a/examples/wifi/embassy_coex/Cargo.toml
+++ b/examples/wifi/embassy_coex/Cargo.toml
@@ -96,6 +96,10 @@ debug-assertions = true
 lto              = "fat"
 codegen-units    = 1
 
+[profile.dev]
+# Keep debug behavior while shrinking code enough for esp32c2 flash limits.
+opt-level = 2
+
 [package.metadata.cargo-machete]
 # Needed for the gatt_server macro.
 ignored = ["embassy-sync"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the latest [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
`examples/wifi/embassy_coex` was overflowing esp32c2 IROM in debug builds during nightly CI (`cargo xtask ... --debug`).

This change adds an example-local dev profile:
- `examples/wifi/embassy_coex/Cargo.toml`
  - `[profile.dev] opt-level = 2`

This keeps the fix scoped to the `embassy_coex` example only, while preserving debuginfo and avoiding global profile changes.

#### Testing
- `cargo +nightly xtask build examples embassy_coex --chip esp32c2 --debug`
  - Result: build succeeds; `Finished dev profile [optimized + debuginfo]`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-566041fe-ee3e-4bd3-9d7e-771b58bc2bd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-566041fe-ee3e-4bd3-9d7e-771b58bc2bd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

