### PR TITLE
Fix CLIC mtvt table symbol check

### DIFF
--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -72,7 +72,7 @@ procmacros               = { version = "0.22.0", package = "esp-hal-procmacros",
 # Dependencies that are optional because they are used by unstable drivers.
 # They are needed when using the `unstable` feature.
 digest                   = { version = "0.10.7", default-features = false, features = ["core-api"], optional = true }
-embassy-usb-driver       = { version = "0.2", optional = true }
+embassy-usb-driver       = { version = "0.2.1", optional = true }
 embassy-usb-synopsys-otg = { version = "0.3.3", optional = true, features = ["host"] }
 embedded-can             = { version = "0.4.1", optional = true }
 nb                       = { version = "1.1", optional = true }

--- a/esp-hal/src/interrupt/riscv/clic.rs
+++ b/esp-hal/src/interrupt/riscv/clic.rs
@@ -207,7 +207,7 @@ _mtvt_table:
 );
 
 // Core 2
-#[cfg(multi_core)]
+#[cfg(all(feature = "rt", multi_core))]
 core::arch::global_asm!(
     r#"
     .section .trap, "ax"

--- a/esp-hal/src/interrupt/riscv/clic.rs
+++ b/esp-hal/src/interrupt/riscv/clic.rs
@@ -129,7 +129,7 @@ mod mintstatus {
     }
 }
 
-#[cfg(feature = "rt")]
+#[cfg(any(feature = "rt", all(feature = "unstable", multi_core)))]
 core::arch::global_asm!(
     r#"
 
@@ -207,7 +207,7 @@ _mtvt_table:
 );
 
 // Core 2
-#[cfg(all(feature = "rt", multi_core))]
+#[cfg(all(any(feature = "rt", feature = "unstable"), multi_core))]
 core::arch::global_asm!(
     r#"
     .section .trap, "ax"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] I have added changelog entries and/or migration guide notes in the sections below, or I will ask a maintainer to add the `skip-changelog` or `manual-changelog` label as appropriate.
- [ ] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
- Gate CLIC MTVT tables to match `init_vectoring()` availability. This prevents `_mtvt_table2` from being emitted as an unmangled global symbol in plain no-`rt` builds used by `check-global-symbols`, while preserving the `unstable + multi_core` no-`rt` app-core startup path.
- Require `embassy-usb-driver` `0.2.1` in `esp-hal`, matching the minimum version required by `embassy-usb-synopsys-otg 0.3.3` and avoiding stale lockfile resolution to `0.2.0`.

#### Testing
- `cargo +nightly fmt --check`
- `cargo +nightly xtask check-global-symbols --chips esp32p4`
- `cargo +nightly build --no-default-features --features esp32p4,rt --target riscv32imafc-unknown-none-elf -Zbuild-std=core`
- `cargo +nightly build --no-default-features --features esp32p4,unstable --target riscv32imafc-unknown-none-elf -Zbuild-std=core`
- `RUSTUP_TOOLCHAIN=nightly cargo xtask lint-packages --chips esp32p4`

---

# Changelog

## esp-hal

- Fixed: Avoid exporting the secondary CLIC MTVT table in plain no-`rt` builds.
- Fixed: Align the optional Embassy USB driver dependency with the Synopsys OTG dependency requirement.

# Migration guide


<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5fa2e20e-6379-4b14-9135-75a4e229d606"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5fa2e20e-6379-4b14-9135-75a4e229d606"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

