### PR TITLE
ci: fix HIL workflow_dispatch artifact upload failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -499,10 +499,29 @@ jobs:
             fi
           done
 
+      - name: Stage test artifacts
+        id: stage-tests
+        run: |
+          STAGE="${RUNNER_TEMP}/hil-tests"
+          rm -rf "$STAGE"
+          mkdir -p "$STAGE"
+          FOUND=0
+          for chip in esp32 esp32s2 esp32s3 esp32c2 esp32c3 esp32c5 esp32c6 esp32c61 esp32h2 esp32p4; do
+            if [ -d "target/tests/$chip" ]; then
+              cp -a "target/tests/$chip" "$STAGE/"
+              FOUND=1
+            fi
+          done
+          if [ "$FOUND" -eq 0 ]; then
+            echo "::error::No test binaries were built for upload"
+            exit 1
+          fi
+          echo "stage=$STAGE" >> "$GITHUB_OUTPUT"
+
       - uses: actions/upload-artifact@v6
         with:
           name: hil-tests
-          path: target/tests/
+          path: ${{ steps.stage-tests.outputs.stage }}/
           if-no-files-found: error
 
   # Device runs — not gated by ci-result.

--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -108,8 +108,8 @@ jobs:
       - uses: actions/checkout@v6
         if: github.event_name == 'workflow_dispatch'
         with:
-          repository: ${{ github.event.inputs.repository }}
-          ref: ${{ github.event.inputs.branch }}
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.branch }}
 
       - uses: esp-rs/xtensa-toolchain@v1.6
         if: steps.arch.outputs.xtensa == 'true'
@@ -147,11 +147,32 @@ jobs:
             fi
           done
 
+      # Only upload chip directories we built. rust-cache can leave stale entries
+      # (e.g. trybuild/, target/) under target/tests/ that break upload-artifact.
+      - name: Stage test artifacts
+        id: stage-tests
+        run: |
+          STAGE="${RUNNER_TEMP}/hil-tests"
+          rm -rf "$STAGE"
+          mkdir -p "$STAGE"
+          CHIPS=$(echo '${{ steps.chips.outputs.matrix }}' | jq -r '.target[].soc')
+          FOUND=0
+          for chip in $CHIPS; do
+            if [ -d "target/tests/$chip" ]; then
+              cp -a "target/tests/$chip" "$STAGE/"
+              FOUND=1
+            fi
+          done
+          if [ "$FOUND" -eq 0 ]; then
+            echo "::warning::No test binaries were built for upload"
+          fi
+          echo "stage=$STAGE" >> "$GITHUB_OUTPUT"
+
       - name: Upload test artifacts
         uses: actions/upload-artifact@v6
         with:
           name: hil-tests
-          path: target/tests/
+          path: ${{ steps.stage-tests.outputs.stage }}/
           if-no-files-found: warn
 
       # xtask runs on the HIL runners as a host tool.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Manual `workflow_dispatch` HIL runs could fail during artifact upload with `ENOENT` on paths like `target/tests/trybuild` and `target/tests/target`. Those entries come from stale rust-cache restores and are not produced by the current `cargo xtask build tests` run, but `upload-artifact` still walks them when uploading all of `target/tests/`.

Slash-command `/hil` dispatches use `hil.yml` from `main` and were less likely to hit this when building a filtered test set, while manual runs that upload the full tree were affected.

## Changes

- Stage only the per-chip directories that were actually built into `${RUNNER_TEMP}/hil-tests` before uploading.
- Apply the same staging step in merge-queue `ci.yml` `hil-build`.
- Use `inputs.repository` / `inputs.branch` for `workflow_dispatch` checkout (equivalent to `github.event.inputs.*`).

## Manual dispatch note

When triggering HIL from the Actions UI, choose **Use workflow from: `main`** so the workflow includes the xtask cross-build/upload steps. Set the **branch** input to the ref you want to test (e.g. a PR head). Feature-branch workflow files that omit the xtask build job will still fail on the device runners even with this fix.

## Testing

- Workflow YAML only; validated structure locally. Full HIL requires hardware runners.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ddd9753-a5b2-486c-8bbc-a80c5049f6ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ddd9753-a5b2-486c-8bbc-a80c5049f6ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

