### PR TITLE
Support test filters in xtask run elfs

### DIFF
--- a/documentation/HIL-GUIDE.md
+++ b/documentation/HIL-GUIDE.md
@@ -51,10 +51,11 @@ Examples:
 - `/hil esp32 esp32c6 --tests rmt, i2c`
 - `/hil esp32c6 hil-test-radio`
 - `/hil esp32c6 hil-test-radio --tests wifi`
+- `/hil esp32s2 --test wifi_controller::test_scan_doesnt_leak`
 
 Both `--test` and `--tests` will work.
 
-Please note that e.g. `/hil esp32s2 --test esp_radio::wifi_controller::tests::test_scan_doesnt_leak` will not work the same as running a specific test via `xtask`, because we use the `xtask` subcommand “run elfs” to run HIL tests in CI. Consequently, the command will be accepted by the bot, but the entire binary file will be run (in the case above, the entire `wifi_controller` test).
+Use `binary::test_name` to run a single embedded-test case inside a matching HIL test binary. For example, `/hil esp32s2 --test wifi_controller::test_scan_doesnt_leak` builds the `wifi_controller` ELF and forwards `test_scan_doesnt_leak` as the embedded-test filter when CI runs the prebuilt ELF.
 
 By default, `/hil` commands run the `hil-test` package. Include `hil-test-radio` in the comment body to run the radio HIL package instead.
 

--- a/xtask/src/commands/run.rs
+++ b/xtask/src/commands/run.rs
@@ -553,11 +553,14 @@ mod tests {
     fn parses_binary_filter() {
         let filters = parse_elf_filters(&strings(&[" misc_non_drivers "])).unwrap();
 
-        assert_eq!(filters, vec![ElfFilter {
-            raw: "misc_non_drivers".to_string(),
-            binary: "misc_non_drivers".to_string(),
-            test_filter: None,
-        }]);
+        assert_eq!(
+            filters,
+            vec![ElfFilter {
+                raw: "misc_non_drivers".to_string(),
+                binary: "misc_non_drivers".to_string(),
+                test_filter: None,
+            }]
+        );
     }
 
     #[test]
@@ -567,11 +570,14 @@ mod tests {
         ]))
         .unwrap();
 
-        assert_eq!(filters, vec![ElfFilter {
-            raw: "Misc_Non_Drivers::wifi_controller::tests::test_scan_doesnt_leak".to_string(),
-            binary: "misc_non_drivers".to_string(),
-            test_filter: Some("wifi_controller::tests::test_scan_doesnt_leak".to_string()),
-        }]);
+        assert_eq!(
+            filters,
+            vec![ElfFilter {
+                raw: "Misc_Non_Drivers::wifi_controller::tests::test_scan_doesnt_leak".to_string(),
+                binary: "misc_non_drivers".to_string(),
+                test_filter: Some("wifi_controller::tests::test_scan_doesnt_leak".to_string()),
+            }]
+        );
     }
 
     #[test]

--- a/xtask/src/commands/run.rs
+++ b/xtask/src/commands/run.rs
@@ -40,7 +40,7 @@ pub enum Run {
 #[cfg_attr(
     feature = "mcp",
     xtask_mcp_macros::mcp_tool(
-        description = "Run all ELFs in a folder using probe-rs",
+        description = "Run all ELFs in a folder using probe-rs. Use --elfs binary or binary::test_name to filter which ELFs/tests run.",
         command = "run elfs"
     )
 )]
@@ -51,7 +51,8 @@ pub struct RunElfsArgs {
     pub chip: Chip,
     /// Path to the ELFs.
     pub path: PathBuf,
-    /// Optional list of elfs to execute
+    /// Optional list of ELFs to execute. Use `binary::test_name` to run a single
+    /// embedded-test case inside a matching ELF.
     #[arg(long, value_delimiter = ',')]
     pub elfs: Vec<String>,
 }
@@ -143,12 +144,8 @@ pub fn run_doc_tests_for_package(workspace: &Path, package: Package, chip: Chip)
 /// Run all (or filtered) ELFs in the specified folder using `probe-rs`.
 pub fn run_elfs(args: RunElfsArgs) -> Result<()> {
     let mut failed: Vec<String> = Vec::new();
-    let filters: Vec<String> = args
-        .elfs
-        .iter()
-        .map(|s| s.trim().to_lowercase())
-        .filter(|s| !s.is_empty())
-        .collect();
+    let filters = parse_elf_filters(&args.elfs)?;
+    let mut filter_matched = vec![false; filters.len()];
 
     let mut elfs = Vec::<(String, PathBuf)>::new();
     for entry in fs::read_dir(&args.path)
@@ -186,90 +183,132 @@ pub fn run_elfs(args: RunElfsArgs) -> Result<()> {
         let elf_name = elf_name.clone();
         let elf_path = elf_path.clone();
 
-        if !filters.is_empty() && !filters.iter().any(|f| elf_name.to_lowercase().contains(f)) {
+        let elf_name_lower = elf_name.to_lowercase();
+        let matching_filter_indices = filters
+            .iter()
+            .enumerate()
+            .filter(|(_, f)| elf_name_lower.contains(&f.binary))
+            .collect::<Vec<_>>();
+
+        if !filters.is_empty() && matching_filter_indices.is_empty() {
             log::info!(
                 "Skipping test '{}' for '{}' (does not match filters: {:?})",
                 elf_name,
                 args.chip,
-                filters,
+                filters.iter().map(|f| f.raw.as_str()).collect::<Vec<_>>(),
             );
             continue;
         }
 
-        log::info!("Running test '{}' for '{}'", elf_name, args.chip);
+        for (index, _) in &matching_filter_indices {
+            filter_matched[*index] = true;
+        }
 
-        if let Some(entry) = radio_manifest.as_ref().and_then(|m| m.get(&elf_name)) {
-            if entry.support_firmware {
-                log::info!("Skipping support firmware '{}'", elf_name);
-                continue;
-            }
+        let test_filters = test_filters_for_elf(&matching_filter_indices, filters.is_empty());
 
-            let harness_path = entry
-                .harness
-                .as_deref()
-                .and_then(|name| resolve_harness_binary_path(&elfs, name));
-
-            if entry.harness.is_some() && harness_path.is_none() {
-                failed.push(elf_name.clone());
-                log::error!(
-                    "Radio test '{}' requires harness firmware '{}' but no matching ELF was found",
+        for test_filter in test_filters {
+            let run_name = elf_run_name(&elf_name, test_filter);
+            if let Some(test_filter) = test_filter {
+                log::info!(
+                    "Running test '{}' for '{}' with filter '{}'",
                     elf_name,
-                    entry.harness.as_deref().unwrap_or_default(),
+                    args.chip,
+                    test_filter
                 );
-                continue;
-            }
-
-            if let Err(e) = run_radio_test_elf(&elf_path, harness_path.as_deref(), 120, None) {
-                failed.push(elf_name.clone());
-                log::error!("Radio test '{}' failed: {}", elf_name, e);
             } else {
-                log::info!("'{}' passed", elf_name);
+                log::info!("Running test '{}' for '{}'", elf_name, args.chip);
             }
-            continue;
-        }
 
-        if let Some(meta) = firmware::find_test_by_name(&radio_tests, &elf_name) {
-            if meta.is_support_firmware() {
-                log::info!("Skipping support firmware '{}' (metadata)", elf_name);
+            if let Some(entry) = radio_manifest.as_ref().and_then(|m| m.get(&elf_name)) {
+                if entry.support_firmware {
+                    log::info!("Skipping support firmware '{}'", elf_name);
+                    continue;
+                }
+
+                let harness_path = entry
+                    .harness
+                    .as_deref()
+                    .and_then(|name| resolve_harness_binary_path(&elfs, name));
+
+                if entry.harness.is_some() && harness_path.is_none() {
+                    failed.push(run_name);
+                    log::error!(
+                        "Radio test '{}' requires harness firmware '{}' but no matching ELF was found",
+                        elf_name,
+                        entry.harness.as_deref().unwrap_or_default(),
+                    );
+                    continue;
+                }
+
+                if let Err(e) =
+                    run_radio_test_elf(&elf_path, harness_path.as_deref(), 120, None, test_filter)
+                {
+                    failed.push(run_name);
+                    log::error!("Radio test '{}' failed: {}", elf_name, e);
+                } else {
+                    log::info!("'{}' passed", elf_name);
+                }
                 continue;
             }
 
-            let harness_path = meta
-                .harness_firmware()
-                .and_then(|name| resolve_harness_binary_path(&elfs, name));
+            if let Some(meta) = firmware::find_test_by_name(&radio_tests, &elf_name) {
+                if meta.is_support_firmware() {
+                    log::info!("Skipping support firmware '{}' (metadata)", elf_name);
+                    continue;
+                }
 
-            if meta.harness_firmware().is_some() && harness_path.is_none() {
-                failed.push(elf_name.clone());
-                log::error!(
-                    "Radio test '{}' requires harness firmware '{}' but no matching ELF was found",
-                    elf_name,
-                    meta.harness_firmware().unwrap_or_default(),
-                );
+                let harness_path = meta
+                    .harness_firmware()
+                    .and_then(|name| resolve_harness_binary_path(&elfs, name));
+
+                if meta.harness_firmware().is_some() && harness_path.is_none() {
+                    failed.push(run_name);
+                    log::error!(
+                        "Radio test '{}' requires harness firmware '{}' but no matching ELF was found",
+                        elf_name,
+                        meta.harness_firmware().unwrap_or_default(),
+                    );
+                    continue;
+                }
+
+                if let Err(e) =
+                    run_radio_test_elf(&elf_path, harness_path.as_deref(), 120, None, test_filter)
+                {
+                    failed.push(run_name);
+                    log::error!("Radio test '{}' failed: {}", elf_name, e);
+                } else {
+                    log::info!("'{}' passed", elf_name);
+                }
                 continue;
             }
 
-            if let Err(e) = run_radio_test_elf(&elf_path, harness_path.as_deref(), 120, None) {
-                failed.push(elf_name.clone());
-                log::error!("Radio test '{}' failed: {}", elf_name, e);
-            } else {
-                log::info!("'{}' passed", elf_name);
+            // Use standard probe-rs runner for non-radio tests.
+            let mut command = Command::new("probe-rs");
+            command.arg("run").arg(&elf_path).arg("--verify");
+            if let Some(test_filter) = test_filter {
+                command.arg(test_filter);
             }
-            continue;
+
+            let status = command.status().context("Failed to execute probe-rs")?;
+
+            log::info!("'{}' done", elf_name);
+
+            if !status.success() {
+                failed.push(run_name);
+            }
         }
+    }
 
-        // Use standard probe-rs runner for non-radio tests.
-        let status = Command::new("probe-rs")
-            .arg("run")
-            .arg(&elf_path)
-            .arg("--verify")
-            .status()
-            .context("Failed to execute probe-rs")?;
-
-        log::info!("'{}' done", elf_name);
-
-        if !status.success() {
-            failed.push(elf_name);
-        }
+    let unmatched_filters = filters
+        .iter()
+        .zip(filter_matched)
+        .filter_map(|(filter, matched)| (!matched).then_some(filter.raw.as_str()))
+        .collect::<Vec<_>>();
+    if !unmatched_filters.is_empty() {
+        bail!(
+            "ELF selector did not match any artifact: {}",
+            unmatched_filters.join(", ")
+        );
     }
 
     if !failed.is_empty() {
@@ -277,6 +316,83 @@ pub fn run_elfs(args: RunElfsArgs) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ElfFilter {
+    raw: String,
+    binary: String,
+    test_filter: Option<String>,
+}
+
+fn parse_elf_filters(raw_filters: &[String]) -> Result<Vec<ElfFilter>> {
+    raw_filters
+        .iter()
+        .filter_map(|raw| {
+            let raw = raw.trim();
+            if raw.is_empty() {
+                return None;
+            }
+
+            Some(parse_elf_filter(raw))
+        })
+        .collect()
+}
+
+fn parse_elf_filter(raw: &str) -> Result<ElfFilter> {
+    let (binary, test_filter) = match raw.split_once("::") {
+        Some((binary, test_filter)) => {
+            let test_filter = test_filter.trim();
+            if test_filter.is_empty() {
+                bail!("Empty test filter in ELF selector '{raw}' is not allowed");
+            }
+            (binary, Some(test_filter.to_string()))
+        }
+        None => (raw, None),
+    };
+
+    let binary = binary.trim().to_lowercase();
+    if binary.is_empty() {
+        bail!("Empty binary filter in ELF selector '{raw}' is not allowed");
+    }
+
+    Ok(ElfFilter {
+        raw: raw.to_string(),
+        binary,
+        test_filter,
+    })
+}
+
+fn test_filters_for_elf<'a>(
+    matching_filter_indices: &[(usize, &'a ElfFilter)],
+    no_filters_requested: bool,
+) -> Vec<Option<&'a str>> {
+    if no_filters_requested
+        || matching_filter_indices
+            .iter()
+            .any(|(_, f)| f.test_filter.is_none())
+    {
+        return vec![None];
+    }
+
+    let mut test_filters = Vec::new();
+    for (_, filter) in matching_filter_indices {
+        let test_filter = filter
+            .test_filter
+            .as_deref()
+            .expect("filtered test selectors must include a test filter");
+        if !test_filters.contains(&Some(test_filter)) {
+            test_filters.push(Some(test_filter));
+        }
+    }
+    test_filters
+}
+
+fn elf_run_name(elf_name: &str, test_filter: Option<&str>) -> String {
+    match test_filter {
+        Some(test_filter) => format!("{elf_name}::{test_filter}"),
+        None => elf_name.to_string(),
+    }
 }
 
 fn load_radio_tests_for_chip(chip: Chip) -> Result<Vec<Metadata>> {
@@ -423,4 +539,75 @@ pub fn run_examples(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn strings(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| (*value).to_string()).collect()
+    }
+
+    #[test]
+    fn parses_binary_filter() {
+        let filters = parse_elf_filters(&strings(&[" misc_non_drivers "])).unwrap();
+
+        assert_eq!(filters, vec![ElfFilter {
+            raw: "misc_non_drivers".to_string(),
+            binary: "misc_non_drivers".to_string(),
+            test_filter: None,
+        }]);
+    }
+
+    #[test]
+    fn parses_binary_test_filter() {
+        let filters = parse_elf_filters(&strings(&[
+            "Misc_Non_Drivers::wifi_controller::tests::test_scan_doesnt_leak",
+        ]))
+        .unwrap();
+
+        assert_eq!(filters, vec![ElfFilter {
+            raw: "Misc_Non_Drivers::wifi_controller::tests::test_scan_doesnt_leak".to_string(),
+            binary: "misc_non_drivers".to_string(),
+            test_filter: Some("wifi_controller::tests::test_scan_doesnt_leak".to_string()),
+        }]);
+    }
+
+    #[test]
+    fn rejects_empty_binary_or_test_filters() {
+        assert!(parse_elf_filters(&strings(&["::test_name"])).is_err());
+        assert!(parse_elf_filters(&strings(&["misc_non_drivers::"])).is_err());
+    }
+
+    #[test]
+    fn runs_once_unfiltered_when_no_filters_were_requested() {
+        let test_filters = test_filters_for_elf(&[], true);
+
+        assert_eq!(test_filters, vec![None]);
+    }
+
+    #[test]
+    fn runs_once_unfiltered_when_any_matching_filter_has_no_test_filter() {
+        let filters =
+            parse_elf_filters(&strings(&["misc_non_drivers::test_a", "misc_non_drivers"])).unwrap();
+        let matching_filter_indices = filters.iter().enumerate().collect::<Vec<_>>();
+        let test_filters = test_filters_for_elf(&matching_filter_indices, false);
+
+        assert_eq!(test_filters, vec![None]);
+    }
+
+    #[test]
+    fn runs_once_per_unique_matching_test_filter() {
+        let filters = parse_elf_filters(&strings(&[
+            "misc_non_drivers::test_a",
+            "misc_non_drivers::test_b",
+            "misc_non_drivers::test_a",
+        ]))
+        .unwrap();
+        let matching_filter_indices = filters.iter().enumerate().collect::<Vec<_>>();
+        let test_filters = test_filters_for_elf(&matching_filter_indices, false);
+
+        assert_eq!(test_filters, vec![Some("test_a"), Some("test_b")]);
+    }
 }

--- a/xtask/src/radio_hil_runner.rs
+++ b/xtask/src/radio_hil_runner.rs
@@ -94,6 +94,7 @@ pub fn run_radio_test_elf(
     harness_binary_path: Option<&Path>,
     timeout_secs: u64,
     probes: Option<String>,
+    test_filter: Option<&str>,
 ) -> Result<()> {
     if !dut_binary_path.exists() {
         bail!("DUT binary not found: {}", dut_binary_path.display());
@@ -142,7 +143,7 @@ pub fn run_radio_test_elf(
         None
     };
 
-    let mut dut_child = spawn_probe_run("DUT", dut_binary_path, dut_probe)?;
+    let mut dut_child = spawn_probe_run("DUT", dut_binary_path, dut_probe, test_filter)?;
     let timeout = Duration::from_secs(timeout_secs);
     let start = Instant::now();
     let dut_passed = loop {
@@ -303,14 +304,29 @@ fn runner_env_key(target: &str) -> String {
     )
 }
 
-fn spawn_probe_run(name: &str, binary_path: &Path, probe: &str) -> Result<Child> {
+fn spawn_probe_run(
+    name: &str,
+    binary_path: &Path,
+    probe: &str,
+    test_filter: Option<&str>,
+) -> Result<Child> {
+    let filter_suffix = test_filter
+        .map(|filter| format!(" {filter}"))
+        .unwrap_or_default();
     log::info!(
-        "[{name}] probe-rs run --preverify --probe {probe} {}",
-        binary_path.display()
+        "[{name}] probe-rs run --preverify --probe {probe} {}{}",
+        binary_path.display(),
+        filter_suffix,
     );
-    Command::new("probe-rs")
+    let mut command = Command::new("probe-rs");
+    command
         .args(["run", "--preverify", "--probe", probe])
-        .arg(binary_path)
+        .arg(binary_path);
+    if let Some(test_filter) = test_filter {
+        command.arg(test_filter);
+    }
+
+    command
         .env("DEFMT_LOG", "info")
         .spawn()
         .map_err(|e| anyhow!("[{name}] failed to spawn probe-rs run: {e}"))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] I have added changelog entries and/or migration guide notes in the sections below, or I will ask a maintainer to add the `skip-changelog` or `manual-changelog` label as appropriate.
- [ ] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Support the existing `binary::test_name` selector convention in `cargo xtask run elfs`. The binary portion continues to match ELF stems as before, while the test-name portion is forwarded to `probe-rs run` so embedded-test can filter the DUT execution. This also reports selectors whose binary portion matches no artifact and updates the HIL guide/MCP tool description.

#### Testing
- `rustfmt +stable --edition 2024 --check xtask/src/commands/run.rs xtask/src/radio_hil_runner.rs`
- `cargo +stable test -p xtask run::tests`
- `cargo +stable check -p xtask`
- `cargo +stable fmt -p xtask -- --check` was attempted, but stable rustfmt reports formatting diffs in pre-existing xtask files outside this change (`xtask/src/commands/mcp.rs`, release files, `xtask/src/documentation.rs`), so only the touched Rust files were checked directly.

---

# Changelog

## xtask

- Fixed: `cargo xtask run elfs --elfs binary::test_name` now forwards the test filter when running matching ELFs.

# Migration guide

- No migration guide necessary.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-59b41a1f-6143-4d71-8602-3702c75e8bb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59b41a1f-6143-4d71-8602-3702c75e8bb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

