### PR TITLE
ci(hil): build radio HIL binaries without defmt trace (fix MQ-only failures)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -495,6 +495,16 @@ jobs:
         run: rm -rf target/tests
 
       - name: Build hil-test-radio tests
+        # defmt filtering is resolved at *compile time* from DEFMT_LOG. The
+        # workflow-level `DEFMT_LOG: trace` bakes trace+debug logging from the
+        # Wi-Fi/BLE stacks into the radio firmware, which floods the ESP32-C6
+        # USB-Serial-JTAG/RTT link during the radio HIL run and makes probe-rs
+        # time out attaching to the harness/DUT. The radio runner only prints at
+        # `info` anyway (see xtask radio_hil_runner), so build the radio
+        # binaries at `info` to keep the link stable and match the
+        # manually-dispatched (hil.yml) path.
+        env:
+          DEFMT_LOG: info
         run: |
           for chip in esp32 esp32s2 esp32s3 esp32c2 esp32c3 esp32c5 esp32c6 esp32c61 esp32h2; do
             if cargo xtask build tests "$chip" hil-test-radio --help >/dev/null 2>&1; then

--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -198,6 +198,13 @@ jobs:
 
       - name: Build hil-test-radio tests
         if: ${{ inputs.package != 'hil-test' }}
+        # Pin the compile-time defmt level so radio binaries are built with the
+        # same (stable) verbosity regardless of trigger. trace/debug logging
+        # from the Wi-Fi/BLE stacks floods the ESP32-C6 USB-Serial-JTAG/RTT link
+        # during the radio HIL run and makes probe-rs time out. The radio runner
+        # only prints at `info` (see xtask radio_hil_runner) anyway.
+        env:
+          DEFMT_LOG: info
         run: |
           CHIPS=$(echo '${{ steps.chips.outputs.matrix }}' | jq -r '.target[].soc')
           TESTS="${{ inputs.tests }}"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Radio HIL (`hil-test-radio`, `esp32c6-radio` runner) **fails deterministically in the merge queue** but **passes when dispatched manually** (`/hil ... hil-test-radio` or `workflow_dispatch`), even on the *same commit*. This PR fixes the underlying workflow difference.

## Root cause

The only build-time difference between the two paths is `DEFMT_LOG`:

- `ci.yml` (merge-queue path) sets `DEFMT_LOG: trace` at **workflow scope** (line 24), inherited by the `hil-build` job.
- `hil.yml` (manual / `/hil` path) never sets `DEFMT_LOG`.

`cargo xtask build tests <chip> hil-test-radio` does **not** inject `DEFMT_LOG` itself (`generate_build_command` only forwards ambient env), and **defmt filtering is resolved at compile time**. So:

- Merge queue → radio firmware compiled with `trace` ⇒ trace+debug logging from the Wi-Fi/BLE stacks is baked in.
- Manual → radio firmware compiled at the default level ⇒ quiet.

During the radio HIL run, the harness ESP32‑C6 runs a Wi‑Fi AP / BLE peripheral while emitting all that trace output over RTT on the USB‑Serial‑JTAG link. The trace flood (combined with concurrent Wi‑Fi activity) overwhelms the link, so probe‑rs times out while attaching/flashing the harness — exactly matching the observed errors:

```
WARN ... read_bulk ... bulk read timed out
Error: Failed to reset, and then halt the CPU. ... USB Communication Error
Error: Connecting to the chip was unsuccessful. ... Timeout during DMI access.
ERROR xtask::commands::run] Radio test 'wifi_has_wifi_ble' failed:
  [HARNESS] probe-rs exited before producing any defmt output
```

### Evidence
- Failing MQ run [27687452315](https://github.com/esp-rs/esp-hal/actions/runs/27687452315/job/81893801934) and working manual run [27682824227](https://github.com/esp-rs/esp-hal/actions/runs/27682824227/job/82098948451) run the identical command (`./xtask run elfs esp32c6 tests/esp32c6`) on the same runner (`CI17046-RPI`) against the same harness probe (`303a:1001:60:55:F9:F6:A3:B4`).
- The MQ radio job's env contains `DEFMT_LOG: trace`; the manual job's env does not.
- `hil-run-radio` fails in every recent `merge_group` run; the manual radio run passes.
- Regular `hil-test` is also built with `trace` and passes — the radio package is uniquely sensitive (two devices doing real RF + heavy logging, tight 90s/3‑min timeouts).

## Change

Build the `hil-test-radio` binaries at `DEFMT_LOG=info` in **both** workflows (`ci.yml` and `hil.yml`), via a step-level `env:` override. This keeps the RTT link stable and makes both trigger paths produce equivalent, reliable binaries. The radio runner (`xtask/src/radio_hil_runner.rs`) already prints at `info` host-side, so no useful output is lost. Regular `hil-test` keeps `trace` (it works on the USB/JTAG runners).

## Verification note

This affects HIL hardware behavior, which can't be exercised from CI here. Please validate by running the merge-queue HIL (or re-queuing) and confirming `hil-run-radio` passes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab942006-d3d2-45fb-9e13-639a7de3a4cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab942006-d3d2-45fb-9e13-639a7de3a4cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

