### PR TITLE
fix(rtc_cntl): report wakeup_cause after light sleep

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - UART: disallow 0 as the RX FIFO full threshold (#5451)
 - UART: prevent returning 0 from `read_async` (#5451)
 - ESP32-S2, ESP32-S3: Fixed a bug where `UlpCore.run()` with `UlpCoreWakeupSource::HpCpu` fails to wake the ULP Core (#5410)
+- `wakeup_cause` now reports the wakeup source after a light sleep, instead of always returning `SleepSource::Undefined` (#3306)
 
 ### Removed
 

--- a/esp-hal/src/rtc_cntl/mod.rs
+++ b/esp-hal/src/rtc_cntl/mod.rs
@@ -440,6 +440,14 @@ impl<'d> Rtc<'d> {
 
         unsafe { crate::time::implem::update_counter(before_ticks + slept_ticks) };
         sleep_uart_resume();
+
+        // Unlike deep sleep, light sleep does not reset the chip, so `wakeup_cause` cannot rely on
+        // the reset reason to tell whether a wakeup occurred. Record that we just returned from a
+        // light sleep so that `wakeup_cause` reads the wakeup cause register. This mirrors the
+        // `s_light_sleep_wakeup` flag used by ESP-IDF.
+        if !config.deep_slp() {
+            LIGHT_SLEEP_WAKEUP.store(true, portable_atomic::Ordering::Relaxed);
+        }
     }
 
     pub(crate) const RTC_DISABLE_ROM_LOG: u32 = 1;
@@ -867,9 +875,18 @@ pub fn reset_reason(cpu: Cpu) -> Option<SocResetReason> {
     SocResetReason::from_repr(reason as usize)
 }
 
+/// Tracks whether the chip has just returned from a light sleep.
+///
+/// Light sleep does not reset the chip, so the reset reason cannot be used to determine whether a
+/// wakeup happened. This flag is set when [`Rtc::sleep`] returns from a non-deep sleep so that
+/// [`wakeup_cause`] still reports a meaningful wakeup source.
+static LIGHT_SLEEP_WAKEUP: portable_atomic::AtomicBool = portable_atomic::AtomicBool::new(false);
+
 /// Return wakeup reason.
 pub fn wakeup_cause() -> SleepSource {
-    if reset_reason(Cpu::ProCpu) != Some(SocResetReason::CoreDeepSleep) {
+    if reset_reason(Cpu::ProCpu) != Some(SocResetReason::CoreDeepSleep)
+        && !LIGHT_SLEEP_WAKEUP.load(portable_atomic::Ordering::Relaxed)
+    {
         return SleepSource::Undefined;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Closes #3306.

`rtc_cntl::wakeup_cause()` always returned `SleepSource::Undefined` whenever the chip was not reset by a deep sleep:

```rust
pub fn wakeup_cause() -> SleepSource {
    if reset_reason(Cpu::ProCpu) != Some(SocResetReason::CoreDeepSleep) {
        return SleepSource::Undefined;
    }
    // ...read wakeup cause register...
}
```

Light sleep does not reset the chip, so the reset reason is never `CoreDeepSleep` after waking from light sleep, and the wakeup source could never be retrieved.

## Solution

This mirrors ESP-IDF, which uses a static `s_light_sleep_wakeup` flag to remember that a light sleep just occurred (see [`sleep_modes.c`](https://github.com/espressif/esp-idf/blob/a45d713b03fd96d8805d1cc116f02a4415b360c7/components/esp_hw_support/sleep_modes.c#L2158)).

- Add a static `LIGHT_SLEEP_WAKEUP` flag, set when `Rtc::sleep` returns from a non-deep sleep (covers both `sleep_light` and the `esp-rtos` auto-lightsleep idle hook, which both go through `Rtc::sleep`).
- `wakeup_cause()` now also reads the wakeup cause register when that flag is set, so it reports the correct `SleepSource` after a light sleep while still behaving identically for deep sleep / cold boot.

## Testing

`cargo check` passes for both register-path variants:
- `esp32c3` (uses `LPWR.slp_wakeup_cause`)
- `esp32c6` (uses `PMU.slp_wakeup_status0`, the `soc_has_pmu` path)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3addb9bd-11fd-4902-9300-4f62f4fb0734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3addb9bd-11fd-4902-9300-4f62f4fb0734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

